### PR TITLE
Feature/installable bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "tape": "^4.6.3",
     "tape-istanbul": "^1.2.0"
   },
+  "bin": {
+     "blockstack-transaction-broadcaster": "./lib/index.js"
+  },
   "scripts": {
     "start": "npm run build && node lib/index.js",
     "build": "babel src -d lib",

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,9 @@
 import { config as bskConfig, network as bskNetwork } from 'blockstack'
 import winston from 'winston'
 import fs from 'fs'
+import os from 'os'
+
+const DB_PATH = '~/transaction_broadcaster.db';
 
 const configDevelopDefaults = {
   winstonConsoleTransport: {
@@ -33,7 +36,7 @@ const configDefaults = {
       json: false
   },
   checkTransactionPeriod: 5,
-  dbLocation: '/root/transaction_broadcaster.db',
+  dbLocation: os.homedir() ? DB_PATH.replace(/^~($|\/|\\)/, `${os.homedir()}$1`) : DB_PATH,
   regtest: false,
   stalenessDeadline: 2*60*60,
   port: 3000,

--- a/src/config.js
+++ b/src/config.js
@@ -2,8 +2,10 @@ import { config as bskConfig, network as bskNetwork } from 'blockstack'
 import winston from 'winston'
 import fs from 'fs'
 import os from 'os'
+import process from 'process'
 
-const DB_PATH = '~/transaction_broadcaster.db';
+const BLOCKSTACK_TEST = process.env.BLOCKSTACK_TEST;
+const DB_PATH = BLOCKSTACK_TEST ? '~/transaction_broadcaster.testnet.db' : '~/transaction_broadcaster.db';
 
 const configDevelopDefaults = {
   winstonConsoleTransport: {

--- a/src/config.js
+++ b/src/config.js
@@ -4,8 +4,8 @@ import fs from 'fs'
 import os from 'os'
 import process from 'process'
 
-const BLOCKSTACK_TEST = process.env.BLOCKSTACK_TEST;
-const DB_PATH = BLOCKSTACK_TEST ? '~/transaction_broadcaster.testnet.db' : '~/transaction_broadcaster.db';
+const BLOCKSTACK_TEST = process.env.BLOCKSTACK_TEST
+const DB_PATH = BLOCKSTACK_TEST ? '~/transaction_broadcaster.testnet.db' : '~/transaction_broadcaster.db'
 
 const configDevelopDefaults = {
   winstonConsoleTransport: {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/node
 import logger from 'winston'
 
 import { makeHTTPServer } from './http'


### PR DESCRIPTION
This set of patches makes it a little bit easier to run in the integration test environment.  It makes this program into a runnable program under /usr/bin, and it makes it so it does not try to store a database under /root/ (but instead expands the `$HOME` variable to find the directory in which to put the transaction DB).  It also makes the name of the DB file dependent on whether or not the system is running in the test environment.