### PR TITLE
Rejects transactions with to-be-consumed inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tape-istanbul": "^1.2.0"
   },
   "bin": {
-     "blockstack-transaction-broadcaster": "./lib/index.js"
+    "blockstack-transaction-broadcaster": "./lib/index.js"
   },
   "scripts": {
     "start": "npm run build && node lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack-transaction-broadcaster",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A transaction broadcaster for Blockstack",
   "main": "lib/index.js",
   "dependencies": {

--- a/src/db.js
+++ b/src/db.js
@@ -87,7 +87,7 @@ export class TransactionQueueDB {
             })
         } else {
           this.tablesExist()
-            .then( exist => {
+            .then(exist => {
               if (exist) {
                 return this.checkCreateInputsTable()
               } else {
@@ -104,12 +104,13 @@ export class TransactionQueueDB {
     return dbAll(this.db, 'SELECT name FROM sqlite_master WHERE type = "table"')
       .then( results => {
         const tables = results.map( x => x.name )
-        return tables.indexOf('inputs_to_consume')
+        return tables.indexOf('inputs_to_consume') >= 0
       })
-      .then( exists => {
+      .then(exists => {
         if (exists) {
           return Promise.resolve()
         } else {
+          logger.info('Creating inputs tracking table')
           return dbRun(this.db, CREATE_INPUTS_TO_CONSUME)
         }
       })
@@ -121,8 +122,8 @@ export class TransactionQueueDB {
         const tables = results.map( x => x.name )
         return tables.indexOf('watch_tx_with_zf_queue') >= 0 &&
           tables.indexOf('watch_tx_with_tx_queue') >= 0 &&
-          tables.indexOf('tx_backups') >= 0
-          tables.indexOf('zonefiles_backups') >= 0
+          tables.indexOf('tx_backups') >= 0 &&
+          tables.indexOf('zonefile_backups') >= 0
       })
   }
 

--- a/src/http.js
+++ b/src/http.js
@@ -36,7 +36,8 @@ export function makeHTTPServer(config) {
     let preorderTx, registerTx
 
     const confirmations = request.confirmations || 4
-    server.broadcastNow(request.preorderTransaction)
+    server.checkAndQueueInputs(request.preorderTransaction)
+      .then(() => server.broadcastNow(request.preorderTransaction))
       .then((txidPreorder) => {
         preorderTx = txidPreorder
         logger.info(`Queueing register to follow tx ${txidPreorder}`)

--- a/tests/src/index.js
+++ b/tests/src/index.js
@@ -13,6 +13,7 @@ function testServer() {
     .reply(200, '<string>{"saved": [1]}</string>')
 
   nock('https://blockchain.info')
+    .persist()
     .post('/pushtx?cors=true')
     .reply(200, 'transaction Submitted')
 
@@ -25,13 +26,22 @@ function testServer() {
              {hash: 'to-watch-2', height: 293},
              {hash: 'to-watch-3', height: 300}]
 
+  const TX1 = '01000000018d5d60122a7907d46f494bcbe34d32e96fc03386ac142823f732c8dd851a98680000' +
+        '000000ffffffff0000000000'
+  const TX2 = '010000000327a201ffa9201abe33344f98377c3c4f87bbc294b87e3adc9a315e160883cb2b0000' +
+        '000000ffffffff423ce7b56485c7ae2454987bb87ab405a22ca77bd4d8edbbea877fa4872a4f83000000' +
+        '0000ffffffff8d5d60122a7907d46f494bcbe34d32e96fc03386ac142823f732c8dd851a986800000000' +
+        '00ffffffff0000000000'
+  const TX3 = '01000000018d5d60122a7907d46f494bcbe34d32e96fc03386ac142823f732c8dd851a98680100' +
+        '000000ffffffff0000000000'
+
   txs.forEach( x => nock('https://blockchain.info')
                .persist()
                .get(`/rawtx/${x.hash}?cors=true`)
                .reply(200, { block_height: x.height }) )
 
   test('queueRegistration', (t) => {
-    t.plan(3)
+    t.plan(4)
 
     let s = new TransactionBroadcaster({ dbLocation: ':memory:',
                                          stalenessDeadline: 60 })
@@ -48,7 +58,21 @@ function testServer() {
       .then(
         () => {
           console.log('queueing transaction 1')
-          return s.queueTransactionToBroadcast('01000000000000000000', 'to-watch-1', 7)
+          return s.queueTransactionToBroadcast(TX1, 'to-watch-1', 7)
+        })
+      .then(
+        () => {
+          console.log('trying tx 2')
+          return s.queueTransactionToBroadcast(TX2, 'to-watch-1', 7)
+        })
+      .then(
+        () => t.ok(false, 'should throw exception when trying to re-use an input in queue'))
+      .catch(
+        () => t.ok(true, 'should throw exception when trying to re-use an input in queue'))
+      .then(
+        () => {
+          console.log('trying tx 3')
+          return s.queueTransactionToBroadcast(TX3, 'to-watch-1', 7)
         })
       .then(
         () => {
@@ -63,7 +87,7 @@ function testServer() {
       .then(
         () =>
           s.db.getTrackedTransactions()
-          .then(entries => t.equal(entries.length, 3)))
+          .then(entries => t.equal(entries.length, 4)))
       .then(() => s.checkWatchlist())
       .then(() => {
         s.db.getTrackedTransactions()


### PR DESCRIPTION
If a transaction's inputs include a UTXO which _will_ be spent by a transaction already in the queue, reject the the queuing request.