### PR TITLE
Update sqlite3 version that works on all current node LTS versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "express": "^4.16.2",
     "node-fetch": "^2.0.0",
     "rwlock": "^5.0.0",
-    "sqlite3": "^3.1.13",
+    "sqlite3": "^4.0.8",
     "winston": "^2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`sqlite3@3.x` dependency does not build on Node active LTS (v10) or greater. 

Updated to `sqlite3@4.x` - major version bump but should not have any breaking changes:
https://github.com/mapbox/node-sqlite3/blob/master/CHANGELOG.md

It also still works on Node v8. 