### PR TITLE
Feature/async lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cors": "^2.8.4",
     "express": "^4.16.2",
     "node-fetch": "^2.0.0",
-    "rwlock": "^5.0.0",
+    "async-lock": "^1.1.3",
     "sqlite3": "^4.0.8",
     "winston": "^2.4.0"
   },


### PR DESCRIPTION
Update the locking library to use the same one as our subdomain registrar. The old locking library would create dead locks after the process ran for a long enough time. The existing test coverage for the locking behavior should cover the new lock usage as well.